### PR TITLE
moved setting the base url and the management key header to a common place for all consumers

### DIFF
--- a/Mobile/ContosoFieldService.Core/Services/BaseAPIService.cs
+++ b/Mobile/ContosoFieldService.Core/Services/BaseAPIService.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using ContosoFieldService.Helpers;
 using Polly;
 using Refit;
 using MonkeyCache.FileStore;
@@ -48,6 +49,20 @@ namespace ContosoFieldService.Services
                         Thread.Sleep(TimeSpan.FromSeconds(retry));
                     }
                 });
+        }
+
+        protected TService GetManagedApiService<TService>()
+        {
+            // Here we set up the stuff that is the same in each http request for our api.
+            // In this case it's the base url and the api management key header.
+            var client = new HttpClient
+            {
+                BaseAddress = new Uri(Constants.BaseUrl)
+            };
+
+            client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", Constants.ApiManagementKey);
+
+            return RestService.For<TService>(client);
         }
 
         public void InvalidateCache(string key = "")

--- a/Mobile/ContosoFieldService.Core/Services/JobsAPIService.cs
+++ b/Mobile/ContosoFieldService.Core/Services/JobsAPIService.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using ContosoFieldService.Models;
-using Polly;
 using Refit;
 using ContosoFieldService.Helpers;
 using MonkeyCache.FileStore;
@@ -17,22 +14,22 @@ namespace ContosoFieldService.Services
     public interface IJobServiceAPI
     {
         [Get("/job/")]
-        Task<List<Job>> GetJobs([Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
+        Task<List<Job>> GetJobs();
 
         [Get("/job/{id}/")]
-        Task<Job> GetJobById(string id, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
+        Task<Job> GetJobById(string id);
 
         [Get("/jobs?keyword={keyword}&suggestions={enableSuggestions}")]
-        Task<List<Job>> SearchJobs(string keyword, bool enableSuggestions, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
+        Task<List<Job>> SearchJobs(string keyword, bool enableSuggestions);
 
         [Post("/job/")]
-        Task<Job> CreateJob([Body] Job job, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
+        Task<Job> CreateJob([Body] Job job);
 
         [Delete("/job/{id}/")]
-        Task<Job> DeleteJob(string id, [Header("Authorization")] string authorization, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
+        Task<Job> DeleteJob(string id, [Header("Authorization")] string authorization);
 
         [Put("/job/{id}/")]
-        Task<Job> UpdateJob(string id, [Body] Job job, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
+        Task<Job> UpdateJob(string id, [Body] Job job);
     }
 
     public class JobsAPIService : BaseAPIService
@@ -40,7 +37,7 @@ namespace ContosoFieldService.Services
         // Note: Usually, we would create only one instance of the IJobServiceAPI here and
         // Re-use it for every operation. For this demo, we can change the BaseUrl at runtime, so we
         // Need a way to create the api for every single call
-        // IJobServiceAPI api = RestService.For<IJobServiceAPI>(Constants.BaseUrl);
+        // IJobServiceAPI api = GetManagedApiService<IJobServiceAPI>();
 
         public JobsAPIService()
         {
@@ -66,10 +63,10 @@ namespace ContosoFieldService.Services
             try
             {
                 // Create an instance of the Refit RestService for the job interface.
-                IJobServiceAPI api = RestService.For<IJobServiceAPI>(Constants.BaseUrl);
+                IJobServiceAPI api = GetManagedApiService<IJobServiceAPI>();
 
                 // Use Polly to handle retrying
-                var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.GetJobs(Constants.ApiManagementKey));
+                var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.GetJobs());
                 if (pollyResult.Result != null)
                 {
                     // Save jobs into the cache
@@ -108,9 +105,9 @@ namespace ContosoFieldService.Services
         public async Task<(ResponseCode code, Job result)> GetJobByIdAsync(string id)
         {
             // Create an instance of the Refit RestService for the job interface.
-            IJobServiceAPI api = RestService.For<IJobServiceAPI>(Constants.BaseUrl);
+            IJobServiceAPI api = GetManagedApiService<IJobServiceAPI>();
 
-            var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.GetJobById(id, Constants.ApiManagementKey));
+            var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.GetJobById(id));
             if (pollyResult.Result != null)
             {
                 return (ResponseCode.Success, pollyResult.Result);
@@ -122,9 +119,9 @@ namespace ContosoFieldService.Services
         public async Task<(ResponseCode code, List<Job> result)> SearchJobsAsync(string keyword, bool enableSuggestions = false)
         {
             // Create an instance of the Refit RestService for the job interface.
-            IJobServiceAPI api = RestService.For<IJobServiceAPI>(Constants.BaseUrl);
+            IJobServiceAPI api = GetManagedApiService<IJobServiceAPI>();
 
-            var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.SearchJobs(keyword, enableSuggestions, Constants.ApiManagementKey));
+            var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.SearchJobs(keyword, enableSuggestions));
             if (pollyResult.Result != null)
             {
                 return (ResponseCode.Success, pollyResult.Result);
@@ -136,9 +133,9 @@ namespace ContosoFieldService.Services
         public async Task<(ResponseCode code, Job result)> CreateJobAsync(Job job)
         {
             // Create an instance of the Refit RestService for the job interface.
-            IJobServiceAPI api = RestService.For<IJobServiceAPI>(Constants.BaseUrl);
+            IJobServiceAPI api = GetManagedApiService<IJobServiceAPI>();
 
-            var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.CreateJob(job, Constants.ApiManagementKey));
+            var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.CreateJob(job));
             if (pollyResult.Result != null)
             {
                 return (ResponseCode.Success, pollyResult.Result);
@@ -150,9 +147,9 @@ namespace ContosoFieldService.Services
         public async Task<(ResponseCode code, Job result)> DeleteJobByIdAsync(string id)
         {
             // Create an instance of the Refit RestService for the job interface.
-            IJobServiceAPI api = RestService.For<IJobServiceAPI>(Constants.BaseUrl);
+            IJobServiceAPI api = GetManagedApiService<IJobServiceAPI>();
 
-            var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.DeleteJob(id, "Bearer " + AuthenticationService.AccessToken, Constants.ApiManagementKey));
+            var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.DeleteJob(id, "Bearer " + AuthenticationService.AccessToken));
             if (pollyResult.Result != null)
             {
                 return (ResponseCode.Success, pollyResult.Result);
@@ -164,9 +161,9 @@ namespace ContosoFieldService.Services
         public async Task<(ResponseCode code, Job result)> UpdateJob(Job job)
         {
             // Create an instance of the Refit RestService for the job interface.
-            IJobServiceAPI api = RestService.For<IJobServiceAPI>(Constants.BaseUrl);
+            IJobServiceAPI api = GetManagedApiService<IJobServiceAPI>();
 
-            var results = await api.UpdateJob(job.Id, job, Constants.ApiManagementKey);
+            var results = await api.UpdateJob(job.Id, job);
             if (results != null)
             {
                 return (ResponseCode.Success, results);

--- a/Mobile/ContosoFieldService.Core/Services/PartsAPIService.cs
+++ b/Mobile/ContosoFieldService.Core/Services/PartsAPIService.cs
@@ -14,19 +14,19 @@ namespace ContosoFieldService.Services
     public interface IPartsServiceAPI
     {
         [Get("/part/")]
-        Task<List<Part>> GetParts([Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
+        Task<List<Part>> GetParts();
 
         [Get("/part/{id}/")]
-        Task<Part> GetPartById(string id, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
+        Task<Part> GetPartById(string id);
 
         [Get("/search/parts/?keyword={keyword}")]
-        Task<List<Part>> SearchParts(string keyword, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
+        Task<List<Part>> SearchParts(string keyword);
 
         [Post("/part/")]
-        Task<Part> CreatePart([Body] Part part, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
+        Task<Part> CreatePart([Body] Part part);
 
         [Post("/part/{id}/")]
-        Task<Part> DeletePart(string id, [Header("Authorization")] string authorization, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
+        Task<Part> DeletePart(string id, [Header("Authorization")] string authorization);
     }
 
     public class PartsAPIService : BaseAPIService
@@ -34,7 +34,7 @@ namespace ContosoFieldService.Services
         // Note: Usually, we would create only one instance of the IPartsServiceAPI here and
         // Re-use it for every operation. For this demo, we can chance the BaseUrl at runtime, so we
         // Need a way to create the api for every single call
-        // readonly IPartsServiceAPI api = RestService.For<IPartsServiceAPI>(Helpers.Constants.BaseUrl);
+        // readonly IPartsServiceAPI api = GetManagedApiService<IPartsServiceAPI>();
 
         public PartsAPIService()
         {
@@ -59,10 +59,10 @@ namespace ContosoFieldService.Services
 
             try
             {
-                IPartsServiceAPI api = RestService.For<IPartsServiceAPI>(Helpers.Constants.BaseUrl);
+                IPartsServiceAPI api = GetManagedApiService<IPartsServiceAPI>();
 
                 // Use Polly to handle retrying
-                var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.GetParts(Constants.ApiManagementKey));
+                var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.GetParts());
                 if (pollyResult.Result != null)
                 {
                     // Save parts into the cache
@@ -94,9 +94,9 @@ namespace ContosoFieldService.Services
 
         public async Task<(ResponseCode code, List<Part> result)> SearchPartsAsync(string keyword)
         {
-            IPartsServiceAPI api = RestService.For<IPartsServiceAPI>(Helpers.Constants.BaseUrl);
+            IPartsServiceAPI api = GetManagedApiService<IPartsServiceAPI>();
 
-            var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.SearchParts(keyword, Constants.ApiManagementKey));
+            var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.SearchParts(keyword));
             if (pollyResult.Result != null)
             {
                 return (ResponseCode.Success, pollyResult.Result);

--- a/Mobile/ContosoFieldService.Core/Services/PhotoAPIService.cs
+++ b/Mobile/ContosoFieldService.Core/Services/PhotoAPIService.cs
@@ -2,7 +2,6 @@
 using ContosoFieldService.Models;
 using Plugin.Media.Abstractions;
 using Refit;
-using ContosoFieldService.Helpers;
 
 namespace ContosoFieldService.Services
 {
@@ -10,17 +9,17 @@ namespace ContosoFieldService.Services
     {
         [Multipart]
         [Post("/photo/{jobId}/")]
-        Task<Job> UploadPhoto(string jobId, [AliasAs("file")] StreamPart stream, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
+        Task<Job> UploadPhoto(string jobId, [AliasAs("file")] StreamPart stream);
     }
 
-    public class PhotoAPIService
+    public class PhotoAPIService : BaseAPIService
     {
         public async Task<Job> UploadPhotoAsync(string jobId, MediaFile file)
         {
-            IPhotoServiceAPI api = RestService.For<IPhotoServiceAPI>(Constants.BaseUrl);
+            IPhotoServiceAPI api = GetManagedApiService<IPhotoServiceAPI>();
 
             var streamPart = new StreamPart(file.GetStream(), "photo.jpg", "image/jpeg");
-            var updatedJob = await api.UploadPhoto(jobId, streamPart, Constants.ApiManagementKey);
+            var updatedJob = await api.UploadPhoto(jobId, streamPart);
             return updatedJob;
         }
     }

--- a/Walkthrough Guide/09 Mobile Network Services/README.md
+++ b/Walkthrough Guide/09 Mobile Network Services/README.md
@@ -25,14 +25,25 @@ It requires us to define our REST API calls as a C# Interface which is then used
 
 
 #### Security 
-Because we’re using Azure API Management, we have the ability to restrict access to our APIs through the use of API Keys. With a unique API key, we’re able to confirm that this app is allowed access to our services. We’ll want to ensure we add the API key to all our requests and Refit makes this super easy! We just need to add the _Headers_ attribute to our interface. Here we grab our API key from the constants class. 
+Because we’re using Azure API Management, we have the ability to restrict access to our APIs through the use of API Keys. With a unique API key, we’re able to confirm that this app is allowed access to our services. We’ll want to ensure we add the API key to all our requests and Refit makes this super easy! We just need to set the `Ocp-Apim-Subscription-Key` header in every request. Here we grab our API key from the constants class and add it to the default headers for the created services. 
 
 
  ```cs
-[Headers(Helpers.Constants.ApiManagementKey)]`
-public interface IJobServiceAPI`
+public abstract class BaseAPIService
 {
+    protected TService GetManagedApiService<TService>()
+    {
+        // Here we set up the stuff that is the same in each http request for our api.
+        // In this case it's the base url and the api management key header.
+        var client = new HttpClient
+        {
+            BaseAddress = new Uri(Constants.BaseUrl)
+        };
 
+        client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", Constants.ApiManagementKey);
+
+        return RestService.For<TService>(client);
+    }
 }
 
 ```


### PR DESCRIPTION
Pull actual API parameters and technical API parameters apart.