### PR TITLE
Fix Add New Job on iOS and Android

### DIFF
--- a/Mobile/ContosoFieldService.Core/Pages/Jobs/CreateNewJobPage.xaml
+++ b/Mobile/ContosoFieldService.Core/Pages/Jobs/CreateNewJobPage.xaml
@@ -7,13 +7,17 @@
     ios:Page.UseSafeArea="true"
     BackgroundColor="{StaticResource BackgroundColor}"
     Title="Create New Job">
+    
+    <Grid CompressedLayout.IsHeadless="true">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
 
-    <ScrollView>
-        <StackLayout CompressedLayout.IsHeadless="true">
-
-           <!-- Form Stack -->
+        <!-- Form Stack -->
+        <ScrollView>
             <StackLayout
-                CompressedLayout.IsHeadless="true"
+                CompressedLayout.IsHeadless="true"                
                 Padding="{StaticResource DefaultThickness}"
                 Spacing="{StaticResource DefaultMargin}"
                 VerticalOptions="FillAndExpand">
@@ -62,22 +66,23 @@
                     Date="{Binding DueDate}"
                     MinimumDate="{Binding CurrentDate}" />
             </StackLayout>  
-            
-            <StackLayout
-                VerticalOptions="End"
-                Spacing="0"
-                CompressedLayout.IsHeadless="true">
-                <Button 
-                    Style="{StaticResource FullWidthButtonStyle}"                    
-                    Text="Create" 
-                    Command="{Binding CreateJobClicked}" />
+        </ScrollView>
+        
+        <StackLayout
+            Grid.Row="1"
+            Spacing="0"
+            CompressedLayout.IsHeadless="true"
+            Padding="{OnPlatform Default='0,10,0,0', iOS='0,10,0,20'}">
+            <Button 
+                Style="{StaticResource FullWidthButtonStyle}"                    
+                Text="Create" 
+                Command="{Binding CreateJobClicked}" />
 
-                <Button 
-                    Style="{StaticResource FullWidthButtonStyle}"
-                    Text="Cancel"                    
-                    BackgroundColor="{StaticResource AccentColorRed}" 
-                    Command="{Binding CancelClicked}" />
-            </StackLayout>
+            <Button 
+                Style="{StaticResource FullWidthButtonStyle}"
+                Text="Cancel"                    
+                BackgroundColor="{StaticResource AccentColorRed}" 
+                Command="{Binding CancelClicked}" />
         </StackLayout>
-    </ScrollView>
+    </Grid>
 </ContentPage>

--- a/Mobile/ContosoFieldService.Core/ViewModels/Jobs/CreateNewJobViewModel.cs
+++ b/Mobile/ContosoFieldService.Core/ViewModels/Jobs/CreateNewJobViewModel.cs
@@ -51,7 +51,7 @@ namespace ContosoFieldService.ViewModels
                     {
                         job = response.result;
                         Analytics.TrackEvent("New Job Created");
-                        await CoreMethods.PopPageModel(job, true, true);
+                        await CoreMethods.PopPageModel(job, false, true);
                     }
                 });
             }

--- a/Mobile/ContosoFieldService.Core/ViewModels/Jobs/JobsViewModel.cs
+++ b/Mobile/ContosoFieldService.Core/ViewModels/Jobs/JobsViewModel.cs
@@ -192,7 +192,7 @@ namespace ContosoFieldService.ViewModels
             base.ReverseInit(returnedData);
             SelectedJob = null;
 
-            if (returnedData is Job job && job.IsDeleted)
+            if (returnedData is Job job)
             {
                 // Job got deleted
                 // Reload data


### PR DESCRIPTION
After creating a new job in the app, we have popped the page in "Modal Mode" in FreshMVVM, although the page is not pushed as a "Modal". This crashed the apps.

This should fix #3 